### PR TITLE
Enable asymmetries

### DIFF
--- a/notebook/ResultNotebook.ipynb
+++ b/notebook/ResultNotebook.ipynb
@@ -140,56 +140,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Delta-g1Z avg: 0.0005822506 std: 0.00281941929146 unc: 0.00170793085\n",
-      "Delta-kappa_gamma avg: 0.00027854785 std: 0.000634932618305 unc: 0.00347488975\n",
-      "Delta-lambda_gamma avg: 0.00055036854 std: 0.00198505402203 unc: 0.0013279658\n",
-      "ChiXS_singleWplussemileptonic_LR avg: 1.00021523 std: 0.000683022724219 unc: 0.0031645749\n",
-      "ChiXS_singleWplussemileptonic_RL avg: 0.98777635 std: 0.0586875293861 unc: 0.0583360465\n",
-      "ChiXS_singleWplussemileptonic_RR avg: 1.000142805 std: 0.00114932429107 unc: 0.0081499086\n",
-      "ChiXS_singleWminussemileptonic_LR avg: 0.99982989 std: 0.000743890475944 unc: 0.00316708615\n",
-      "ChiXS_singleWminussemileptonic_RL avg: 1.0058629 std: 0.0488368955281 unc: 0.058753859\n",
-      "ChiXS_singleWminussemileptonic_LL avg: 0.99434431 std: 0.00799849492393 unc: 0.0106115465\n",
-      "ChiXS_WW_semilep_MuAntiNu_LR avg: 0.985770995 std: 0.0414008262668 unc: 0.026346183\n",
-      "ChiXS_WW_semilep_MuAntiNu_RL avg: 1.31339945 std: 0.281789618345 unc: 0.47806343\n",
-      "ChiXS_WW_semilep_AntiMuNu_LR avg: 0.962400385 std: 0.0464176923108 unc: 0.0274426205\n",
-      "ChiXS_WW_semilep_AntiMuNu_RL avg: 1.043486575 std: 0.363329035777 unc: 0.46396264\n",
-      "ChiXS_ZZsemileptonic_LR avg: 1.0014304 std: 0.00015485638508 unc: 0.00411507585\n",
-      "ChiXS_ZZsemileptonic_RL avg: 0.99929954 std: 0.00322138050519 unc: 0.005142461\n",
-      "ChiXS_Zhadronic_LR avg: 0.999982815 std: 0.000408969349035 unc: 0.0031018239\n",
-      "ChiXS_Zhadronic_RL avg: 1.0001326 std: 9.81464212287e-05 unc: 0.0030937572\n",
-      "ChiXS_Zleptonic_LR avg: 1.00010049 std: 0.000579558859996 unc: 0.00311270565\n",
-      "ChiXS_Zleptonic_RL avg: 1.000021525 std: 0.000754023316118 unc: 0.0031062306\n",
-      "Lumi250GeV avg: 2000.00005 std: 7.07106781009e-05 unc: 6.13866095\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jakob/anaconda3/lib/python3.5/site-packages/matplotlib/pyplot.py:516: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
-      "  max_open_warning, RuntimeWarning)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ePol- avg: 0.799835755 std: 0.000100204101962 unc: 0.000493344625\n",
-      "ePol+ avg: 0.800164375 std: 0.000189200561442 unc: 0.000239678145\n",
-      "pPol- avg: 0.299941835 std: 8.70660579675e-05 unc: 0.000397499765\n",
-      "pPol+ avg: 0.30014189 std: 0.000474892914245 unc: 0.000486673325\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for p in range(n_pars):\n",
     "    p_avg = par_avg[p] # Average result of current parameter\n",
@@ -238,20 +193,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jakob/anaconda3/lib/python3.5/site-packages/matplotlib/pyplot.py:516: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
-      "  max_open_warning, RuntimeWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Create figure for plots and adjust height and width\n",
     "fig_cor, ax_cor = plt.subplots()\n",
@@ -288,27 +234,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jakob/anaconda3/lib/python3.5/site-packages/matplotlib/pyplot.py:516: RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).\n",
-      "  max_open_warning, RuntimeWarning)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average $\\chi^2$: 58255.488\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "chi_sq_min = np.amin(chi_sqs) # Smallest chi^2 found\n",
     "chi_sq_max = np.amax(chi_sqs) # Largest chi^2 found\n",

--- a/notebook/ResultNotebook.ipynb
+++ b/notebook/ResultNotebook.ipynb
@@ -261,6 +261,46 @@
     "fig_chi_sq.savefig(\"../output/hist_chisq.pdf\")\n",
     "print(r\"Average $\\chi^2$: \" + str(chi_sq_avg))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot cov. matrix calculation status statitics to detect if problems occured"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "cov_status_arr = np.empty(n_fits)\n",
+    "for f in range(n_fits):\n",
+    "    cov_status_arr[f] = result.fit_results[f].cov_status\n",
+    "    \n",
+    "fig_cov_stat, ax_cov_stat = plt.subplots(tight_layout=True)\n",
+    "hist_cov_stat = ax_cov_stat.hist(cov_status_arr, range=(-1.5,3.5), bins=5, histtype='step', color='black')\n",
+    "ax_cov_stat.set_xlabel(\"Cov. matr. status\")\n",
+    "ax_cov_stat.set_ylabel(\"#Toys\")\n",
+    "ax_cov_stat.set_yscale('log')\n",
+    "\n",
+    "y_lims_cov_stat = ax_cov_stat.get_ylim()\n",
+    "ax_cov_stat.set_ylim(0.9, 1.2*np.amax(hist_cov_stat[0]))\n",
+    "\n",
+    "fig_cov_stat.savefig(\"../output/hist_cov_status.pdf\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -67,25 +67,49 @@ int main (int /*argc*/, char **/*argv*/) {
   // setup.set_WW_mu_only();
   setup.set_ZZ_mu_only();
   
-  // Set all chiral cross sections as free parameters
-  setup.free_chiral_xsection("singleWplussemileptonic", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("singleWplussemileptonic", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("singleWplussemileptonic", PREW::GlobalVar::Chiral::eRpR);
-  setup.free_chiral_xsection("singleWminussemileptonic", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("singleWminussemileptonic", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("singleWminussemileptonic", PREW::GlobalVar::Chiral::eLpL);
-  // setup.free_chiral_xsection("WWsemileptonic", PREW::GlobalVar::Chiral::eLpR);
-  // setup.free_chiral_xsection("WWsemileptonic", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("WW_semilep_MuAntiNu", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("WW_semilep_MuAntiNu", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("WW_semilep_AntiMuNu", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("WW_semilep_AntiMuNu", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("ZZsemileptonic", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("ZZsemileptonic", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("Zhadronic", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("Zhadronic", PREW::GlobalVar::Chiral::eRpL);
-  setup.free_chiral_xsection("Zleptonic", PREW::GlobalVar::Chiral::eLpR);
-  setup.free_chiral_xsection("Zleptonic", PREW::GlobalVar::Chiral::eRpL);
+  // // Set chiral cross sections as free parameters (Here: use total xs and asymm instead)
+  // setup.free_chiral_xsection("singleWplussemileptonic", PREW::GlobalVar::Chiral::eLpR);
+  
+  // Set asymmetries and total chiral cross sections scalings as free parameters
+  setup.free_asymmetry(
+    "singleWminussemileptonic",
+    PREW::GlobalVar::Chiral::eLpR,
+    PREW::GlobalVar::Chiral::eRpL,
+    PREW::GlobalVar::Chiral::eLpL
+  );
+  setup.free_asymmetry(
+    "singleWplussemileptonic",
+    PREW::GlobalVar::Chiral::eRpL,
+    PREW::GlobalVar::Chiral::eLpR,
+    PREW::GlobalVar::Chiral::eRpR
+  );
+  setup.free_asymmetry(
+    "WW_semilep_MuAntiNu", 
+    PREW::GlobalVar::Chiral::eLpR, PREW::GlobalVar::Chiral::eRpL
+  );
+  setup.free_asymmetry(
+    "WW_semilep_AntiMuNu", 
+    PREW::GlobalVar::Chiral::eLpR, PREW::GlobalVar::Chiral::eRpL
+  );
+  setup.free_asymmetry(
+    "ZZsemileptonic", 
+    PREW::GlobalVar::Chiral::eLpR, PREW::GlobalVar::Chiral::eRpL
+  );
+  setup.free_asymmetry(
+    "Zhadronic", 
+    PREW::GlobalVar::Chiral::eLpR, PREW::GlobalVar::Chiral::eRpL
+  );
+  setup.free_asymmetry(
+    "Zleptonic", 
+    PREW::GlobalVar::Chiral::eLpR, PREW::GlobalVar::Chiral::eRpL
+  );
+  setup.free_total_chiral_xsection("singleWminussemileptonic");
+  setup.free_total_chiral_xsection("singleWplussemileptonic");
+  setup.free_total_chiral_xsection("WW_semilep_MuAntiNu");
+  setup.free_total_chiral_xsection("WW_semilep_AntiMuNu");
+  setup.free_total_chiral_xsection("ZZsemileptonic");
+  setup.free_total_chiral_xsection("Zhadronic");
+  setup.free_total_chiral_xsection("Zleptonic");
   
   spdlog::info("Finalizing linking info.");
   setup.complete_setup(); // This must come last in linking setup

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -24,8 +24,8 @@ int main (int /*argc*/, char **/*argv*/) {
   
   spdlog::info("Add files and energies.");
   setup.add_input_file("../../PrEW/testdata/RK_examplefile_500_250_2018_04_03.root");
-  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/omega/ww_qqmunu_chargeseparated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root");
-  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/omega/ww_qqmunu_chargeseparated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root");
+  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root");
+  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root");
   setup.add_energy( energy );
 
   spdlog::info("Selecting distributions.");


### PR DESCRIPTION
- Adapt to new (laptop) local WW file location.
- Disable deprecated free single chiral cross sections.
- Enable newly added chiral asymmetries and total chiral cross sections as free parameters.
- Remove leftover outputs from notebook.
- Add a plot to the notenbook that shows the status of the covariance matrix calculation.