### PR TITLE
Adapt to home office

### DIFF
--- a/macros/load_env.sh
+++ b/macros/load_env.sh
@@ -1,3 +1,22 @@
 #!/bin/bash
 
-source ../../PrEW/macros/load_env.sh
+# Script tries to use the setup used by PrEW 
+# => Tries to find it on my NAF, else see if a local version exists
+
+PrEW_NAF_dir="/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/PrEW"
+PrEW_local_dir="../../PrEW"
+
+PrEW_dir=""
+
+if [ -d "${PrEW_NAF_dir}" ] ; then
+  echo "Found PrEW on NAF."
+  PrEW_dir="${PrEW_NAF_dir}"
+elif [ -d "${PrEW_local_dir}" ] ; then
+  echo "Found PrEW on local computer."
+  PrEW_dir="${PrEW_local_dir}"
+else 
+  echo "ERROR: Did not find PrEW!"
+  exit
+fi
+
+source ${PrEW_dir}/macros/load_env.sh

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -23,9 +23,9 @@ int main (int /*argc*/, char **/*argv*/) {
   PrEWUtils::Setups::RKDistrSetup setup {};
   
   spdlog::info("Add files and energies.");
-  setup.add_input_file("../../PrEW/testdata/RK_examplefile_500_250_2018_04_03.root");
-  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root");
-  setup.add_input_file("/home/jakob/Documents/DESY/MountPoints/DUSTMount/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root");
+  setup.add_input_file("/afs/desy.de/group/flc/pool/beyerjac/TGCAnalysis/PrEW/testdata/RK_examplefile_500_250_2018_04_03.root");
+  setup.add_input_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_MuAntiNu.root");
+  setup.add_input_file("/nfs/dust/ilc/group/ild/beyerjac/TGCAnalysis/SampleProduction/WW_charge_separated/distributions/combined/Distribution_250GeV_WW_semilep_AntiMuNu.root");
   setup.add_energy( energy );
 
   spdlog::info("Selecting distributions.");


### PR DESCRIPTION
- Adapt the load_env.sh macro to the different paths of PrEW at home and on NAF.
- Switch input paths to be the paths on NAF by default (instead of local computer).

